### PR TITLE
Timeout thread

### DIFF
--- a/bridge/watchers.py
+++ b/bridge/watchers.py
@@ -3,7 +3,7 @@ from web3 import Web3, HTTPProvider
 import json
 import sys
 import logging
-import thread
+import _thread as thread
 from func_timeout import func_set_timeout, FunctionTimedOut
 from time import sleep, time
 from hashlib import sha256 as _sha256
@@ -80,6 +80,7 @@ class Watcher(DaemonThread):
 
     @func_set_timeout(60)            
     def run_eth(self):
+        sleep(61)
         #get all addresses and amounts of all transactions received to the deposit address
         self.logger.info("Getting eth burn txs...")
         received_txs = self.eth.get_burn_txs()

--- a/bridge/watchers.py
+++ b/bridge/watchers.py
@@ -80,7 +80,6 @@ class Watcher(DaemonThread):
 
     @func_set_timeout(60)            
     def run_eth(self):
-        sleep(61)
         #get all addresses and amounts of all transactions received to the deposit address
         self.logger.info("Getting eth burn txs...")
         received_txs = self.eth.get_burn_txs()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ eth-keys==0.3.3
 ecdsa==0.15
 coincurve==13.0.0
 bitcoin==1.1.39
+func-timeout==4.3.5


### PR DESCRIPTION
Apply a timeout to the execution of run_ocean() and run_eth() in watcher. Interrupt the main thread on timeout.